### PR TITLE
let PAS decide where to store user properties

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,8 @@
 1.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Let PAS decide where to store user properties. Allows e.g. Membrane
+  to store properties on the user object itself. [gweis]
 
 
 0.9 (2014-02-04)

--- a/Products/AutoUserMakerPASPlugin/auth.py
+++ b/Products/AutoUserMakerPASPlugin/auth.py
@@ -81,10 +81,11 @@ class AutoUserMakerPASPlugin(BasePlugin):
         This is utilised when first creating a user, and to update
         their information when logging in again later.
         """
-        userProps = user.getPropertysheet('mutable_properties')
-        for ii in ('fullname', 'description', 'email', 'location'):
-            if credentials.has_key(ii):
-                userProps.setProperty(user, ii, credentials[ii])
+        userProps = dict((key, credentials[key]) for
+                         key in ('fullname', 'description',
+                                 'email', 'location')
+                         if credentials.get(key) is not None)
+        user.setProperties(**userProps)
 
     def _generatePassword(self):
         """ Return a obfuscated password never used for login """


### PR DESCRIPTION
Membrane user content doesn't store properties in mutable_properties sheet.
Letting PAS decide where to store user properties, makes this plugin work for alternative property sheets as well.
