### PR TITLE
remove triggering of UserLoggedInEvent (shouldn't be done in PAS plugin)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 1.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Remove triggering of UserLoggedInEvent (shouldn't be done in PAS plugin)
 
 
 1.0 (2014-02-26)

--- a/Products/AutoUserMakerPASPlugin/auth.py
+++ b/Products/AutoUserMakerPASPlugin/auth.py
@@ -6,7 +6,6 @@ import re
 import string
 
 from persistent.list import PersistentList
-from zope.event import notify
 from AccessControl import ClassSecurityInfo
 try:
     # Zope >= 2.12
@@ -27,9 +26,6 @@ from Products.PluggableAuthService.permissions import ManageUsers
 from Products.PluggableAuthService.PluggableAuthService import logger
 from Products.PluggableAuthService.plugins.BasePlugin import BasePlugin
 from Products.PluggableAuthService.utils import classImplements
-
-from Products.PlonePAS.events import UserLoggedInEvent
-from Products.PlonePAS.events import UserInitialLoginInEvent
 
 from Products.PluggableAuthService.PluggableAuthService import \
     _SWALLOWABLE_PLUGIN_EXCEPTIONS
@@ -195,12 +191,10 @@ class AutoUserMakerPASPlugin(BasePlugin):
             source_groups = getToolByName(self, 'source_groups')
             for ii in groups:
                 source_groups.addPrincipalToGroup(user.getId(), ii)
-            notify(UserInitialLoginInEvent(user))
         else:
             config = self.getConfig()
             if config.get(autoUpdateUserPropertiesKey, 0):
                 self._updateUserProperties(user, credentials)
-            notify(UserLoggedInEvent(user))
 
         #Allow other plugins to handle credentials; eg session or cookie
         pas.updateCredentials(self.REQUEST,


### PR DESCRIPTION
In case the whole site is protected via a shibboleth session, firing the events in the plugin will trigger a UserLoggedInEvent on every request.

Instead the login form handling within Plone (and later possibly plone.login) should fire these events.
