### PR TITLE
Fixed error - Always redirecting to authentication page

### DIFF
--- a/Products/AutoUserMakerPASPlugin/auth.py
+++ b/Products/AutoUserMakerPASPlugin/auth.py
@@ -404,8 +404,8 @@ class ExtractionPlugin(BasePlugin, PropertyManager):
         >>> handler.getSharingConfig()
         {'http_sharing_tokens': (), 'http_sharing_labels': ()}
         """
-        return {httpSharingTokensKey: self.getProperty(httpSharingTokensKey),
-                httpSharingLabelsKey: self.getProperty(httpSharingLabelsKey)}
+        return {httpSharingTokensKey: self.getProperty(httpSharingTokensKey, ()),
+                httpSharingLabelsKey: self.getProperty(httpSharingLabelsKey, ())}
 
     security.declareProtected(ManageUsers, 'getTokens')
     def getTokens(self):
@@ -417,7 +417,7 @@ class ExtractionPlugin(BasePlugin, PropertyManager):
         >>> handler.getTokens()
         ()
         """
-        return self.getProperty(httpAuthzTokensKey)
+        return self.getProperty(httpAuthzTokensKey, ())
 
     security.declareProtected(ManageUsers, 'getMapping')
     def getMapping(self):
@@ -480,7 +480,7 @@ class ExtractionPlugin(BasePlugin, PropertyManager):
         >>> handler.requiredRoles()
         ()
         """
-        return self.getProperty('required_roles', [])
+        return self.getProperty('required_roles', ())
 
     security.declarePrivate('loginUsers')
     def loginUsers(self):
@@ -492,7 +492,7 @@ class ExtractionPlugin(BasePlugin, PropertyManager):
         >>> handler.loginUsers()
         ()
         """
-        return self.getProperty('login_users', [])
+        return self.getProperty('login_users', ())
 
     security.declarePrivate('defaultRoles')
     def defaultRoles(self):

--- a/Products/AutoUserMakerPASPlugin/auth.py
+++ b/Products/AutoUserMakerPASPlugin/auth.py
@@ -244,12 +244,14 @@ class AutoUserMakerPASPlugin(BasePlugin):
 
     security.declarePrivate('challenge')
     def challenge(self, request, response):
-        url = self.loginUrl(request.ACTUAL_URL)
-        if url:
-            response.redirect(url, lock=True)
-            return True
-        else:  # Pass off control to the next challenge plugin.
-            return False
+        # Just Start a challenge, if not logged yet
+        if request.getHeader(httpRemoteUserKey, None) == None:
+            url = self.loginUrl(request.ACTUAL_URL)
+            if url:
+                response.redirect(url, lock=True)
+                return True
+        # Pass off control to the next challenge plugin.
+        return False
 
 classImplements(AutoUserMakerPASPlugin, IAuthenticationPlugin, IChallengePlugin)
 

--- a/Products/AutoUserMakerPASPlugin/tests/test_plugin.py
+++ b/Products/AutoUserMakerPASPlugin/tests/test_plugin.py
@@ -24,10 +24,17 @@ class AutoUserMakerPASPluginTests(PluginTestCase):
 
     def test_challenge(self):
         class DummyReq(object):
+            authenticated = False
 
             def __init__(self, url):
                 self.ACTUAL_URL = url
 
+            def getHeader(self, header, default):
+                if self.authenticated:
+                    return "SOME VALUE"
+                else:
+                    return default
+ 
         class DummyResp(object):
             url = ''
 
@@ -37,6 +44,15 @@ class AutoUserMakerPASPluginTests(PluginTestCase):
         request = DummyReq('http://www.example.org/')
         response = DummyResp()
         self.assertFalse(response.url)
+
+
+        # Authenticated already
+        request.authenticated = True
+        self.plugin.challenge(request, response)
+        self.assertFalse(response.url)
+
+        # Not yet atuthenticated
+        request.authenticated = False
         self.plugin.challenge(request, response)
         self.assertEqual(response.url, 'https://www.example.org/')
 


### PR DESCRIPTION
The user is always redirected to the authentication URI, even if he was authenticated (logged) already, if he has no right to execute some action.
The "challenge" process must to verify if the 'authentication HTTP headers' are not present before to redirect.