### PR TITLE
Support Periodic Updates Of User Properties

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,9 @@
 - Update default buildout to Plone 5.0
   [tomgross]
 
+- Support periodic user properties updates
+  [sebasgo]
+
 2.0 (2016-01-14)
 ================
 

--- a/Products/AutoUserMakerPASPlugin/Extensions/Install.py
+++ b/Products/AutoUserMakerPASPlugin/Extensions/Install.py
@@ -2,6 +2,7 @@
 # aren't using Plone, it doesn't hurt anything.
 
 from Products.AutoUserMakerPASPlugin.auth import ApacheAuthPluginHandler
+from Products.AutoUserMakerPASPlugin.auth import LAST_UPDATE_USER_PROPERTY_KEY
 from Products.CMFCore.utils import getToolByName
 from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin
 from Products.PluggableAuthService.interfaces.plugins import IChallengePlugin
@@ -84,6 +85,10 @@ def install(portal, reinstall=False):
             acl_users.manage_delProperties([ii])
         except:
             pass
+    memberdata = getToolByName(portal, 'portal_memberdata')
+    if LAST_UPDATE_USER_PROPERTY_KEY not in memberdata.propertyIds():
+        memberdata.manage_addProperty(id=LAST_UPDATE_USER_PROPERTY_KEY, type='float', value=0.0)
+
 
 def uninstall(portal, reinstall=False):
     acl_users = getToolByName(portal, 'acl_users')
@@ -109,3 +114,6 @@ def uninstall(portal, reinstall=False):
             #logger.info("mappings = %s" % repr(mappings))
             acl_users.manage_addProperty(id='aum_mappings', type='lines', value=mappings)
         acl_users.manage_delObjects(ids=[pluginId])  # implicitly deactivates
+    memberdata = getToolByName(portal, 'portal_memberdata')
+    if LAST_UPDATE_USER_PROPERTY_KEY in memberdata.propertyIds():
+        memberdata.manage_delProperties([LAST_UPDATE_USER_PROPERTY_KEY])

--- a/Products/AutoUserMakerPASPlugin/config.zpt
+++ b/Products/AutoUserMakerPASPlugin/config.zpt
@@ -183,15 +183,25 @@
 
     <h3 i18n:translate="heading_auto_update_user_properties">User Properties Update</h3>
     <p>
+        When enabling this option, make sure this plugin runs only
+        once per login session or set an adequate high update interval,
+        otherwise it will update user properties on every request
+        potentially causing ConflictErrors.
+    </p>
+    <p>
       <input type="checkbox" id="auto_update_user_properties"
              name="auto_update_user_properties" value="1"
              tal:attributes="checked python:'checked' if config['auto_update_user_properties'] else ''"/>
       <label for="auto_update_user_properties" i18n:translate="description_auto_update_user_properties">
         Automatically update user properties with values from request
-        headers.<br/>
-        When enabling this option, make sure this plugin runs only
-        once per login session, otherwise it will update user
-        properties on every request potentially causing ConflictErrors.
+        headers.
+      </label>
+    </p>
+    <p>
+      <input type="text" name="auto_update_user_properties_interval"
+             tal:attributes="value config/auto_update_user_properties_interval">
+      <label for="http_state" i18n:translate="auto_update_user_properties_interval">
+        Update interval (in seconds)
       </label>
     </p>
 

--- a/Products/AutoUserMakerPASPlugin/tests/AutoUserMakerPASPlugin.txt
+++ b/Products/AutoUserMakerPASPlugin/tests/AutoUserMakerPASPlugin.txt
@@ -158,6 +158,7 @@ Now, let's check the default configuration:
 
     >>> inOrder(apache.getConfig())
     'auto_update_user_properties':0
+    'auto_update_user_properties_interval':86400
     'challenge_header_enabled':False
     'challenge_header_name':
     'challenge_pattern':http://(.*)
@@ -200,6 +201,7 @@ pseudo REQUEST object, then get the results and print in order.
     >>> apache.manage_changeConfig(request)
     >>> inOrder(apache.getConfig())
     'auto_update_user_properties':0
+    'auto_update_user_properties_interval':0
     'challenge_header_enabled':True
     'challenge_header_name':Foo
     'challenge_pattern':http://example.org(.*)
@@ -225,6 +227,7 @@ the above output.
     >>> request = MockForm({'no_such_field': 'junk'})
     >>> inOrder(apache.getConfig())
     'auto_update_user_properties':0
+    'auto_update_user_properties_interval':0
     'challenge_header_enabled':True
     'challenge_header_name':Foo
     'challenge_pattern':http://example.org(.*)


### PR DESCRIPTION
Previously the addon allowed to update user properties only on every
request. For deployments in which the addon processes every request
to the site this option could not be used since the risk of
ConflicErrors was to high. This commit introduces a new option which
performs the update only in configurable intervals (one day by
default).

Tests passed, we use it successfully in production.