### PR TITLE
Skip CSRF Protection When Updating User

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,10 @@
 - Support periodic user properties updates
   [sebasgo]
 
+- Exclude user creation and update from plone.protect's CSRF protection
+  [sebasgo]
+
+
 2.0 (2016-01-14)
 ================
 


### PR DESCRIPTION
Plone's automatic CSRF protection doesn't allow write transactions without a token. Which we don't have all the time when logging in via Shibboleth, which can happen anytime for any request. So mark the changed objects as safe to write to.